### PR TITLE
🔧 Adds a .prettierignore file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.vscode
+package.json


### PR DESCRIPTION
Tell `prettier` to ignore the `package.json` file and `.vscode` dir.